### PR TITLE
Add pass/fail stats, streaming and DB comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # data_reconcilation_framework
 
-This repository provides a small utility to compare two delimited text files
-and highlight differences at the row and column level.  It can also generate a
-simple diff report and send it to a recipient via email.
+This repository provides a small utility to compare two data sources and
+highlight differences at the row and column level.  It generates a summary of
+pass and fail counts and can email the failing records.  Sources may be
+delimited text files or results from SQLite database queries.
 
 ## Usage
 
@@ -11,17 +12,27 @@ simple diff report and send it to a recipient via email.
 ```
 
 The wrapper script invokes the Python program `compare.py` which performs the
-actual comparison.  If an email address is supplied, the tool will attempt to
-send the report using the SMTP server defined by the `SMTP_SERVER` environment
-variable (default `localhost`).  The sender address can be customised with
-`MAIL_SENDER`.
+actual comparison.  If an email address is supplied and differences are found,
+the tool will send the failing records using the SMTP server defined by the
+`SMTP_SERVER` environment variable (default `localhost`).  The sender address
+can be customised with `MAIL_SENDER`.
 
-The Python script can also be executed directly:
+The Python script can also be executed directly.  Besides files, it can pull
+data from SQLite databases:
 
 ```sh
-python3 compare.py old_file.csv new_file.csv --email recipient@example.com
+# compare two files
+python3 compare.py old_file.csv new_file.csv
+
+# compare a file with a query result
+python3 compare.py data.csv --db2 data.db --query2 "SELECT * FROM table"
+
+# email only the failing records
+python3 compare.py old.csv new.csv --email recipient@example.com
 ```
 
-The report printed to standard output lists mismatched rows, per-column
-statistics and counts of extra rows.  The email feature is optional so the tool
-can still be used in environments without email configuration.
+The report printed to standard output lists per-column statistics, counts of
+extra rows and numbers of passing and failing records.  Processing is streamed
+row by row so datasets of 10GB or more can be handled without exhausting
+memory.  The email feature is optional so the tool can still be used in
+environments without email configuration.

--- a/compare.py
+++ b/compare.py
@@ -2,77 +2,113 @@
 """
 Data comparison tool.
 
-Compares two delimited text files and reports differences at the row and
-column level. Optionally sends an email with the report.
+Compares two delimited text files or database queries and reports differences
+at the row and column level. Generates a summary with pass/fail counts and can
+optionally email only the failing records.
 """
+
 import argparse
 import csv
 import os
 import smtplib
+import sqlite3
 from email.message import EmailMessage
+from itertools import zip_longest
 
 
-def read_table(path, delimiter):
-    """Return the table at *path* as a list of rows."""
+def iter_table(path, delimiter):
+    """Yield rows from the delimited file at *path*."""
     with open(path, newline="") as handle:
         reader = csv.reader(handle, delimiter=delimiter)
-        return list(reader)
+        for row in reader:
+            yield row
 
 
-def compare_tables(table1, table2):
-    """Compare two tables and return diff metrics."""
-    max_rows = max(len(table1), len(table2))
-    max_cols = max(len(table1[0]) if table1 else 0,
-                   len(table2[0]) if table2 else 0)
+def iter_db(db_path, query):
+    """Yield rows resulting from executing *query* on the SQLite database."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cur = conn.cursor()
+        for row in cur.execute(query):
+            yield [str(col) for col in row]
+    finally:
+        conn.close()
 
-    column_diffs = [0] * max_cols
+
+def compare_iterators(rows1, rows2):
+    """Compare two row iterators and return diff metrics."""
+    column_diffs = []
     mismatched_rows = []
-    cell_differences = 0
+    failed_records = []
+    pass_count = 0
+    fail_count = 0
+    rows_file1 = 0
+    rows_file2 = 0
 
-    for i in range(max_rows):
-        row1 = table1[i] if i < len(table1) else [""] * max_cols
-        row2 = table2[i] if i < len(table2) else [""] * max_cols
+    for idx, (row1, row2) in enumerate(zip_longest(rows1, rows2, fillvalue=None)):
+        if row1 is not None:
+            rows_file1 += 1
+        else:
+            row1 = []
+        if row2 is not None:
+            rows_file2 += 1
+        else:
+            row2 = []
 
-        if len(row1) < max_cols:
-            row1.extend([""] * (max_cols - len(row1)))
-        if len(row2) < max_cols:
-            row2.extend([""] * (max_cols - len(row2)))
+        max_cols = max(len(row1), len(row2))
+        if len(column_diffs) < max_cols:
+            column_diffs.extend([0] * (max_cols - len(column_diffs)))
 
         row_mismatch = False
         for j in range(max_cols):
-            if row1[j] != row2[j]:
+            v1 = row1[j] if j < len(row1) else ""
+            v2 = row2[j] if j < len(row2) else ""
+            if v1 != v2:
                 column_diffs[j] += 1
-                cell_differences += 1
                 row_mismatch = True
+
         if row_mismatch:
-            mismatched_rows.append(i + 1)  # 1-indexed
+            fail_count += 1
+            mismatched_rows.append(idx + 1)  # 1-indexed
+            failed_records.append((idx + 1, row1, row2))
+        else:
+            pass_count += 1
+
+    extra_rows_file1 = max(0, rows_file1 - rows_file2)
+    extra_rows_file2 = max(0, rows_file2 - rows_file1)
+    cell_differences = sum(column_diffs)
 
     return {
-        "rows_file1": len(table1),
-        "rows_file2": len(table2),
-        "extra_rows_file1": max(0, len(table1) - len(table2)),
-        "extra_rows_file2": max(0, len(table2) - len(table1)),
+        "rows_file1": rows_file1,
+        "rows_file2": rows_file2,
+        "extra_rows_file1": extra_rows_file1,
+        "extra_rows_file2": extra_rows_file2,
         "cell_differences": cell_differences,
         "column_differences": {
             f"col{idx + 1}": diff for idx, diff in enumerate(column_diffs) if diff
         },
         "mismatched_rows": mismatched_rows,
+        "pass_count": pass_count,
+        "fail_count": fail_count,
+        "failed_records": failed_records,
     }
 
 
-def format_report(file1, file2, metrics):
+def format_summary(source1, source2, metrics):
     """Format diff *metrics* into a human readable report."""
     lines = [
         "Comparison Report",
         "=================",
-        f"File 1: {file1}",
-        f"File 2: {file2}",
+        f"Source 1: {source1}",
+        f"Source 2: {source2}",
         "",
-        f"Rows in File 1: {metrics['rows_file1']}",
-        f"Rows in File 2: {metrics['rows_file2']}",
-        f"Extra rows in File 1: {metrics['extra_rows_file1']}",
-        f"Extra rows in File 2: {metrics['extra_rows_file2']}",
+        f"Rows in Source 1: {metrics['rows_file1']}",
+        f"Rows in Source 2: {metrics['rows_file2']}",
+        f"Extra rows in Source 1: {metrics['extra_rows_file1']}",
+        f"Extra rows in Source 2: {metrics['extra_rows_file2']}",
         f"Cell differences: {metrics['cell_differences']}",
+        f"Pass records: {metrics['pass_count']}",
+        f"Fail records: {metrics['fail_count']}",
     ]
     if metrics["column_differences"]:
         lines.append("Column differences:")
@@ -82,6 +118,18 @@ def format_report(file1, file2, metrics):
         lines.append(
             "Rows with differences: " + ", ".join(map(str, metrics["mismatched_rows"]))
         )
+    return "\n".join(lines)
+
+
+def format_failed_records(failed_records):
+    """Format the list of *failed_records* for output or email."""
+    if not failed_records:
+        return "No failing records"
+    lines = ["Failed Records", "=============="]
+    for row_no, row1, row2 in failed_records:
+        lines.append(f"Row {row_no}:")
+        lines.append(f"  source1: {','.join(row1)}")
+        lines.append(f"  source2: {','.join(row2)}")
     return "\n".join(lines)
 
 
@@ -100,29 +148,57 @@ def send_email(recipient, subject, body):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Compare two delimited text files and report differences."
+        description="Compare two delimited text files or database queries and report differences."
     )
-    parser.add_argument("file1", help="first file to compare")
-    parser.add_argument("file2", help="second file to compare")
+    parser.add_argument("file1", nargs="?", help="first file to compare")
+    parser.add_argument("file2", nargs="?", help="second file to compare")
     parser.add_argument(
         "--delimiter",
         default=",",
         help="field delimiter used in the files (default: comma)",
     )
+    parser.add_argument("--db1", help="path to SQLite database for first dataset")
+    parser.add_argument("--query1", help="SQL query for first dataset")
+    parser.add_argument("--db2", help="path to SQLite database for second dataset")
+    parser.add_argument("--query2", help="SQL query for second dataset")
     parser.add_argument(
-        "--email", help="send report to this email address", metavar="ADDRESS"
+        "--email", help="send failed records to this email address", metavar="ADDRESS"
     )
     args = parser.parse_args()
 
-    table1 = read_table(args.file1, args.delimiter)
-    table2 = read_table(args.file2, args.delimiter)
-    metrics = compare_tables(table1, table2)
-    report = format_report(args.file1, args.file2, metrics)
-    print(report)
+    if args.db1:
+        if not args.query1:
+            parser.error("--db1 requires --query1")
+        iter1 = iter_db(args.db1, args.query1)
+        source1 = f"{args.db1}:{args.query1}"
+    else:
+        if not args.file1:
+            parser.error("file1 or --db1 must be specified")
+        iter1 = iter_table(args.file1, args.delimiter)
+        source1 = args.file1
 
-    if args.email:
+    if args.db2:
+        if not args.query2:
+            parser.error("--db2 requires --query2")
+        iter2 = iter_db(args.db2, args.query2)
+        source2 = f"{args.db2}:{args.query2}"
+    else:
+        if not args.file2:
+            parser.error("file2 or --db2 must be specified")
+        iter2 = iter_table(args.file2, args.delimiter)
+        source2 = args.file2
+
+    metrics = compare_iterators(iter1, iter2)
+    summary = format_summary(source1, source2, metrics)
+    print(summary)
+
+    if metrics["fail_count"]:
+        print("\n" + format_failed_records(metrics["failed_records"]))
+
+    if args.email and metrics["fail_count"]:
         try:
-            send_email(args.email, "Data comparison report", report)
+            body = format_failed_records(metrics["failed_records"])
+            send_email(args.email, "Failed records report", body)
             print(f"\nEmail sent to {args.email}")
         except Exception as exc:
             print(f"\nFailed to send email: {exc}")
@@ -130,3 +206,4 @@ def main():
 
 if __name__ == "__main__":
     raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- report pass and fail counts and email only failing rows
- stream file and database inputs to handle very large datasets
- support comparing against SQLite query results

## Testing
- `python -m py_compile compare.py`
- `python compare.py examples/old.csv examples/new.csv`
- `python compare.py examples/old.csv --db2 examples/data.db --query2 "SELECT id, name, age FROM t ORDER BY id"`


------
https://chatgpt.com/codex/tasks/task_e_68ad9ed1b76c833385f4bedcd65bf294